### PR TITLE
Use env vars for database configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_HOST=localhost
+DB_NAME=hephreeair
+DB_USER=root
+DB_PASSWORD=your_password

--- a/README.md
+++ b/README.md
@@ -38,20 +38,29 @@ flight-tracker
    composer install
    ```
 
-3. **Configure Database**
-   Update the `config/database.php` file with your database connection details:
-   ```php
-   <?php
-   return [
-       'host' => 'your_database_host',
-       'username' => 'your_database_username',
-       'password' => 'your_database_password',
-       'dbname' => 'your_database_name',
-   ];
+3. **Configure Environment**
+   Copy the provided `.env.example` file to `.env` and update the values with
+   your database credentials:
+   ```bash
+   cp .env.example .env
    ```
+   The application reads the following environment variables:
+   - `DB_HOST` – database server hostname
+   - `DB_NAME` – name of the database
+   - `DB_USER` – database user
+   - `DB_PASSWORD` – database password
 
 4. **Run the Application**
    You can use a local server like XAMPP or MAMP to run the application. Place the project in the server's root directory and navigate to `http://localhost/flight-tracker/public/index.php` in your web browser.
+
+## Environment Variables
+The application expects the following variables to be set, either in your shell
+environment or in a `.env` file:
+
+- `DB_HOST` – database server hostname
+- `DB_NAME` – name of the database
+- `DB_USER` – database user
+- `DB_PASSWORD` – database password
 
 ## Usage
 - **View Flights**: The application will display a list of all flights you have added.
@@ -60,3 +69,4 @@ flight-tracker
 
 ## Contributing
 Feel free to submit issues or pull requests if you would like to contribute to the project.
+

--- a/config/database.php
+++ b/config/database.php
@@ -1,9 +1,9 @@
 <?php
 // Database configuration
-$host = 'localhost'; // Database host
-$dbname = 'hephreeair'; // Database name
-$username = 'root'; // Database username
-$password = 'VeryKnies23!'; // Database password
+$host = getenv('DB_HOST') ?: 'localhost';
+$dbname = getenv('DB_NAME') ?: 'hephreeair';
+$username = getenv('DB_USER') ?: 'root';
+$password = getenv('DB_PASSWORD') ?: '';
 
 try {
     // Create a new PDO instance

--- a/config/eloquent.php
+++ b/config/eloquent.php
@@ -6,10 +6,10 @@ $capsule = new Capsule;
 
 $capsule->addConnection([
     'driver'    => 'mysql',
-    'host'      => 'localhost',
-    'database'  => 'hephreeair',
-    'username'  => 'root',
-    'password'  => 'VeryKnies23!',
+    'host'      => getenv('DB_HOST') ?: 'localhost',
+    'database'  => getenv('DB_NAME') ?: 'hephreeair',
+    'username'  => getenv('DB_USER') ?: 'root',
+    'password'  => getenv('DB_PASSWORD') ?: '',
     'charset'   => 'utf8mb4',
     'collation' => 'utf8mb4_0900_ai_ci',
     'prefix'    => '',
@@ -20,3 +20,4 @@ $capsule->setAsGlobal();
 
 // Setup the Eloquent ORM
 $capsule->bootEloquent();
+


### PR DESCRIPTION
## Summary
- load database connection details from environment variables
- document required environment variables in README
- add `.env.example` for reference

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f82904b3c83238be2bea07ae1dae7