### PR TITLE
Fix migration column and correct view includes

### DIFF
--- a/migrations/2023_10_01_000000_create_airlines_table.php
+++ b/migrations/2023_10_01_000000_create_airlines_table.php
@@ -7,8 +7,8 @@ if (!Capsule::schema()->hasTable('airlines')) {
     Capsule::schema()->create('airlines', function (Blueprint $table) {
         $table->increments('AirlineID')->unique();
         $table->string('AirlineName');
+        $table->string('code');
         $table->date('AirlineFromDate');
-        $table->date('AirlineToDate');
         $table->date('AirlineToDate');
         $table->integer('RenamedToAirlineID');
         $table->timestamps();

--- a/src/views/airlines/index.php
+++ b/src/views/airlines/index.php
@@ -1,8 +1,8 @@
 <?php
 // This file is responsible for rendering the view that displays the list of airlines.
 
-require_once '../../../config/database.php';
-require_once '../../models/Airline.php';
+require_once __DIR__ . '/../../../config/database.php';
+require_once __DIR__ . '/../../models/Airline.php';
 
 $airlines = Airline::all(); // Fetch all airlines from the database
 

--- a/src/views/flights/index.php
+++ b/src/views/flights/index.php
@@ -1,8 +1,8 @@
 <?php
 // This file is responsible for rendering the view that displays the list of flights.
 
-require_once '../../../config/database.php';
-require_once '../../models/Flight.php';
+require_once __DIR__ . '/../../../config/database.php';
+require_once __DIR__ . '/../../models/Flight.php';
 
 $flights = []; // This will hold the list of flights, fetched from the database or controller
 


### PR DESCRIPTION
## Summary
- fix airline migration by adding `code` field and removing the duplicate `AirlineToDate`
- load config and models correctly in views using `__DIR__`

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f813f089883238145a6bda06cc556