### PR TITLE
Add quick start instructions and route

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@
 ## Overview
 The Flight Tracker is a web application designed to help users track and manage their commercial aviation flights. Users can add new flights, view a list of their flights, and delete flights they no longer wish to keep in their records.
 
+## Quick Start
+Install dependencies and launch a local server with PHP's built-in server:
+
+```bash
+composer install
+php -S localhost:8000 -t public
+```
+
+Open <http://localhost:8000> in your browser to see the app.
+
+
 ## Project Structure
 ```
 flight-tracker

--- a/public/index.php
+++ b/public/index.php
@@ -17,6 +17,7 @@ $app->get('/', [$controller, 'index']);
 $app->post('/flights', [$controller, 'addFlight']);
 $app->delete('/flights/{id}', [$controller, 'deleteFlight']);
 $app->get('/airlines', [$controller, 'showAirlines']);
+$app->get('/quickstart', [$controller, 'quickStart']);
 
 $app->run();
 ?>

--- a/src/controllers/FlightController.php
+++ b/src/controllers/FlightController.php
@@ -4,6 +4,9 @@ namespace App\Controllers;
 
 use App\Models\Flight;
 use App\Models\Airline;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+use Illuminate\Database\Capsule\Manager as Capsule;
 
 class FlightController
 {
@@ -58,6 +61,16 @@ class FlightController
 
         ob_start();
         require __DIR__ . '/../views/airlines/index.php';
+        $output = ob_get_clean();
+
+        $response->getBody()->write($output);
+        return $response;
+    }
+
+    public function quickStart(Request $request, Response $response, array $args): Response
+    {
+        ob_start();
+        require __DIR__ . '/../views/quickstart.php';
         $output = ob_get_clean();
 
         $response->getBody()->write($output);

--- a/src/views/quickstart.php
+++ b/src/views/quickstart.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/css/styles.css">
+    <title>Quick Start</title>
+</head>
+<body>
+    <h1>Flight Tracker Quick Start</h1>
+    <p>This page is a minimal starting point.</p>
+    <ul>
+        <li><a href="/">View Flights</a></li>
+        <li><a href="/airlines">Manage Airlines</a></li>
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Quick Start section to README
- allow GET /quickstart to show a minimal starting page
- implement quickStart method and required imports

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_683f852324b483238510fd98c4b122d0